### PR TITLE
Feature/support v2 package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SPM-Acknowledgments",
-	platforms: [.iOS("11.0")],
+	platforms: [.iOS("15.0")],
     products: [
         .library(
             name: "SPM-Acknowledgments",
@@ -19,5 +19,5 @@ let package = Package(
             name: "SPM-AcknowledgmentsTests",
             dependencies: ["SPM-Acknowledgments"]),
 	],
-	swiftLanguageVersions: [.v4_2]
+	swiftLanguageVersions: [.v5]
 )

--- a/Sources/SPM-Acknowledgments/AcknowledgmentsTableViewController.swift
+++ b/Sources/SPM-Acknowledgments/AcknowledgmentsTableViewController.swift
@@ -22,7 +22,7 @@ final public class AcknowledgmentsTableViewController: UITableViewController {
 		tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
 		footerView.frame.size = footerView.systemLayoutSizeFitting(CGSize(width: view.frame.width, height: .greatestFiniteMagnitude),
 																	 withHorizontalFittingPriority: .defaultHigh, verticalFittingPriority: .defaultLow)
-		tableView.tableFooterView = footerView
+//		tableView.tableFooterView = footerView
 	}
 	
 	override public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Sources/SPM-Acknowledgments/AcknowledgmentsTextViewController.swift
+++ b/Sources/SPM-Acknowledgments/AcknowledgmentsTextViewController.swift
@@ -56,14 +56,12 @@ internal class AcknowledgmentsTextViewController: UIViewController {
 	}
 	
 	override func viewDidAppear(_ animated: Bool) {
-		let task = URLSession.shared.downloadTask(with: package.licenseURL) { [weak self] localURL, urlResponse, error in
-			guard let self = self, let localURL = localURL else { return }
-			DispatchQueue.main.async {
-				self.textView.text = try? String(contentsOf: localURL)
-				self.loadingSpinner.stopAnimating()
-			}
-		}
-		task.resume()
+        package.fetchLicense { licenseText in
+            DispatchQueue.main.async {
+                self.textView.text = licenseText ?? "No license found."
+                self.loadingSpinner.stopAnimating()
+            }
+        }
 	}
 	
 	@available(*, unavailable)

--- a/Sources/SPM-Acknowledgments/AcknowledgmentsTextViewController.swift
+++ b/Sources/SPM-Acknowledgments/AcknowledgmentsTextViewController.swift
@@ -56,7 +56,8 @@ internal class AcknowledgmentsTextViewController: UIViewController {
 	}
 	
 	override func viewDidAppear(_ animated: Bool) {
-        package.fetchLicense { licenseText in
+        Task {
+            let licenseText = await package.fetchLicense()
             DispatchQueue.main.async {
                 self.textView.text = licenseText ?? "No license found."
                 self.loadingSpinner.stopAnimating()

--- a/Sources/SPM-Acknowledgments/ParsePackages.swift
+++ b/Sources/SPM-Acknowledgments/ParsePackages.swift
@@ -7,38 +7,84 @@
 //
 
 import Foundation
+import SwiftUI
 
-internal struct Package: Codable {
+internal struct Package: Decodable {
 	let name: String
-	let licenseURL: URL
-	var license: String = ""
-	
-	private enum CodingKeys: String, CodingKey{
-		case name = "package"
-		case licenseURL = "repositoryURL"
+	let licenseURLMain: URL
+    let licenseURLMaster: URL
+
+	private enum CodingKeys: String, CodingKey {
+		case name = "identity"
+		case licenseURL = "location"
 	}
 	
 	init(from decoder: Decoder) throws {
 		let values = try decoder.container(keyedBy: CodingKeys.self)
 		name = try values.decode(String.self, forKey: .name)
 		let baseURL = try values.decode(URL.self, forKey: .licenseURL)
-		licenseURL = baseURL.appendingPathComponent("/raw/master/LICENSE")
+		licenseURLMain = baseURL.appendingPathComponent("/raw/main/LICENSE")
+        licenseURLMaster = baseURL.appendingPathComponent("/raw/master/LICENSE")
 	}
 }
 
 internal class ParsePackages {
-	private struct Object: Codable {
-		var object: Pins
-	}
-	
-	private struct Pins: Codable {
+	private struct Pins: Decodable {
 		var pins: [Package]
 	}
 	
 	func parsePackages() -> [Package] {
 		guard let packagesPath = Bundle.main.path(forResource: "Package", ofType: "resolved"),
 			let data = try? Data(contentsOf: URL(fileURLWithPath: packagesPath)) ,
-			let json = try? JSONDecoder().decode(Object.self, from: data) else { return [] }
-        return json.object.pins.filter({ $0.name != "SPM-Acknowledgments" && !$0.licenseURL.absoluteString.contains(".git/") })
+			let json = try? JSONDecoder().decode(Pins.self, from: data) else {
+            return []
+        }
+        json.pins.forEach { print($0) }
+        return json.pins.filter({ $0.name != "SPM-Acknowledgments" && !$0.licenseURLMain.absoluteString.contains(".git/") })
 	}
+}
+
+extension Package {
+    typealias FetchLicenseCompletion = (String?) -> Void
+
+    func fetchLicense(_ completion: @escaping FetchLicenseCompletion) {
+        // First try to get the license from the `master` branch. If not found, use `main` branch.
+        let firstURLAttempt = licenseURLMaster
+        let secondURLAttempt = licenseURLMain
+
+        fetchLicense(at: firstURLAttempt) { license in
+            if let license = license {
+                completion(license)
+            } else {
+                fetchLicense(at: secondURLAttempt) { license in
+                    if let license = license {
+                        completion(license)
+                    } else {
+                        completion(nil)
+                    }
+                }
+            }
+        }
+    }
+
+    private func fetchLicense(at url: URL, _ completion: @escaping FetchLicenseCompletion) {
+        let task = URLSession.shared.downloadTask(with: url) { localURL, urlResponse, error in
+
+            // The license should be plain text. If it's HTML, we probably got a 404 for using the wrong branch name.
+            let expectedMimeType = "text/plain"
+
+            guard
+                let mimeType = urlResponse?.mimeType,
+                mimeType == expectedMimeType,
+                let localURL = localURL,
+                let license = try? String(contentsOf: localURL)
+            else {
+                completion(nil)
+                return
+            }
+
+            completion(license)
+        }
+        task.resume()
+    }
 }

--- a/Sources/SPM-Acknowledgments/ParsePackages.swift
+++ b/Sources/SPM-Acknowledgments/ParsePackages.swift
@@ -40,7 +40,7 @@ internal class ParsePackages {
             return []
         }
         json.pins.forEach { print($0) }
-        return json.pins.filter({ $0.name != "SPM-Acknowledgments" && !$0.licenseURLMain.absoluteString.contains(".git/") })
+        return json.pins.filter({ !$0.licenseURLMain.absoluteString.contains(".git/") })
 	}
 }
 


### PR DESCRIPTION
- Adds support for v2 Package.resolved files
- Drops support for v1 Package.resolved files
- Drops support for anything below iOS 15.0 (uses async/await)
- Uses Swift 5
- Attempts to find licenses at both `main` and `master` branches uses both `LICENSE` and `LICENSE.md` filenames. 